### PR TITLE
Remove additional brackets from cluster setup guide

### DIFF
--- a/guides/hosting/installation-updates/cluster-setup.md
+++ b/guides/hosting/installation-updates/cluster-setup.md
@@ -54,7 +54,7 @@ We recommend setting up at least five Redis servers for the following resources:
 
 1. [Session](../performance/session) + [cart](../infrastructure/database-cluster#cart-in-redis)
 1. [cache.object](../performance/caches#example-replace-some-cache-with-redis)
-1. [Lock](../performance/lock-store)) + [Increment storage](../performance/increment))
+1. [Lock](../performance/lock-store) + [Increment storage](../performance/increment)
 1. [Number Ranges](../performance/number-ranges)
 1. [Message Queue](../infrastructure/message-queue#transport-redis-example)  
    Instead of setting up a Redis server for `messenger`, you can also work directly with [RabbitMQ](../infrastructure/message-queue#transport-rabbitmq-example)


### PR DESCRIPTION
Remove closing brackets from cluster setup guide, as they're typos